### PR TITLE
initial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Alien::Build::Plugin::Download::GitLab ![static](https://github.com/PerlAlien/Alien-Build-Plugin-Download-GitLab/workflows/static/badge.svg) ![linux](https://github.com/PerlAlien/Alien-Build-Plugin-Download-GitLab/workflows/linux/badge.svg)
+
+Alien::Build plugin to download from GitLab
+
+# AUTHOR
+
+Graham Ollis <plicease@cpan.org>
+
+# COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2022 by Graham Ollis.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,82 @@
 
 Alien::Build plugin to download from GitLab
 
+# SYNOPSIS
+
+```perl
+use alienfile;
+
+plugin 'Download::GitLab' => (
+  gitlab_user    => 'plicease',
+  gitlab_project => 'dontpanic',
+);
+```
+
+# DESCRIPTION
+
+This plugin is designed for downloading assets from a GitLab instance.
+
+# PROPERTIES
+
+## gitlab\_host
+
+The host to fetch from [https://gitlab.com](https://gitlab.com) by default.
+
+## gitlab\_user
+
+The user to fetch from.
+
+## gitlab\_project
+
+The project to fetch from.
+
+## type
+
+The asset type to fetch.  This must be one of `source` or `link`.
+
+## format
+
+The expected format of the asset.  This should be one that
+[Alien::Build::Plugin::Extract::Negotiate](https://metacpan.org/pod/Alien::Build::Plugin::Extract::Negotiate) understands.  The
+default is `tar.gz`.
+
+## version\_from
+
+Where to compute the version from.  This should be one of
+`tag_name` or `name`.  The default is `tag_name`.
+
+## convert\_version
+
+This is an optional code reference, which can be used to modify
+the version.  For example, if tags have a `v` prefix you could
+remove it like so:
+
+```perl
+plugin 'Download::GitLab' => (
+  gitlab_user     => 'plicease',
+  gitlab_project  => 'dontpanic',
+  convert_version => sub {
+    my $version = shift;
+    $version =~ s/^v//;
+    return $version;
+  },
+);
+```
+
+## link\_name
+
+For `link` types, this is a regular expression that filters the
+asset filenames.  For example, if there are multiple archive
+formats provided, you can get just the gzip'd tarball by setting
+this to `qr/\.tar\.gz$/`.
+
+# SEE ALSO
+
+- [Alien](https://metacpan.org/pod/Alien)
+- [Alien::Build::Plugin::Download::GitHub](https://metacpan.org/pod/Alien::Build::Plugin::Download::GitHub)
+- [alienfile](https://metacpan.org/pod/alienfile)
+- [Alien::Build](https://metacpan.org/pod/Alien::Build)
+
 # AUTHOR
 
 Graham Ollis <plicease@cpan.org>

--- a/author.yml
+++ b/author.yml
@@ -7,6 +7,7 @@ pod_spelling_system:
   # intentionally
   stopwords:
     - GitLab
+    - gzip'd
 
 pod_coverage:
   skip: 0

--- a/author.yml
+++ b/author.yml
@@ -5,12 +5,12 @@ pod_spelling_system:
   # (regardless of what spell check thinks)
   # or stuff that I like to spell incorrectly
   # intentionally
-  stopwords: []
+  stopwords:
+    - GitLab
 
 pod_coverage:
   skip: 0
   # format is "Class#method" or "Class",regex allowed
   # for either Class or method.
-  private: []
-
-
+  private:
+    - Alien::Build::Plugin::Download::GitLab

--- a/lib/Alien/Build/Plugin/Download/GitLab.pm
+++ b/lib/Alien/Build/Plugin/Download/GitLab.pm
@@ -3,9 +3,15 @@ package Alien::Build::Plugin::Download::GitLab;
 use strict;
 use warnings;
 use 5.008004;
+use Alien::Build::Plugin;
 
 # ABSTRACT: Alien::Build plugin to download from GitLab
 # VERSION
+
+sub init
+{
+  my($self, $meta) = @_;
+}
 
 1;
 

--- a/lib/Alien/Build/Plugin/Download/GitLab.pm
+++ b/lib/Alien/Build/Plugin/Download/GitLab.pm
@@ -3,16 +3,226 @@ package Alien::Build::Plugin::Download::GitLab;
 use strict;
 use warnings;
 use 5.008004;
+use Carp qw( croak );
+use URI;
+use JSON::PP qw( decode_json );
+use URI::Escape qw( uri_escape );
 use Alien::Build::Plugin;
+use File::Basename qw( basename );
+use Path::Tiny qw( path );
 
 # ABSTRACT: Alien::Build plugin to download from GitLab
 # VERSION
 
+=head1 SYNOPSIS
+
+ use alienfile;
+ 
+ plugin 'Download::GitLab' => (
+   gitlab_user    => 'plicease',
+   gitlab_project => 'dontpanic',
+ );
+
+=head1 DESCRIPTION
+
+This plugin is designed for downloading assets from a GitLab instance.
+
+=head1 PROPERTIES
+
+=head2 gitlab_host
+
+The host to fetch from L<https://gitlab.com> by default.
+
+=head2 gitlab_user
+
+The user to fetch from.
+
+=head2 gitlab_project
+
+The project to fetch from.
+
+=cut
+
+has gitlab_host    => 'https://gitlab.com';
+has gitlab_user    => undef;
+has gitlab_project => undef;
+
+=head2 type
+
+The asset type to fetch.  This must be one of C<source> or C<link>.
+
+=cut
+
+has type => 'source';  # source or link
+
+=head2 format
+
+The expected format of the asset.  This should be one that
+L<Alien::Build::Plugin::Extract::Negotiate> understands.  The
+default is C<tar.gz>.
+
+=cut
+
+has format => 'tar.gz';
+
+=head2 version_from
+
+Where to compute the version from.  This should be one of
+C<tag_name> or C<name>.  The default is C<tag_name>.
+
+=head2 convert_version
+
+This is an optional code reference, which can be used to modify
+the version.  For example, if tags have a C<v> prefix you could
+remove it like so:
+
+ plugin 'Download::GitLab' => (
+   gitlab_user     => 'plicease',
+   gitlab_project  => 'dontpanic',
+   convert_version => sub {
+     my $version = shift;
+     $version =~ s/^v//;
+     return $version;
+   },
+ );
+
+=head2 link_name
+
+For C<link> types, this is a regular expression that filters the
+asset filenames.  For example, if there are multiple archive
+formats provided, you can get just the gzip'd tarball by setting
+this to C<qr/\.tar\.gz$/>.
+
+=cut
+
+has version_from    => 'tag_name'; # tag_name or name
+has convert_version => undef;
+has link_name       => undef;
+
 sub init
 {
   my($self, $meta) = @_;
+
+  croak("No gitlab_user provided") unless defined $self->gitlab_user;
+  croak("No gitlab_project provided") unless defined $self->gitlab_project;
+  croak("Don't set set a start_url with the Download::GitLab plugin") if defined $meta->prop->{start_url};
+
+  $meta->add_requires('configure' => 'Alien::Build::Plugin::Download::GitLab' => 0 );
+
+  my $url = URI->new($self->gitlab_host);
+  $url->path("/api/v4/projects/@{[ uri_escape(join '/', $self->gitlab_user, $self->gitlab_project) ]}/releases");
+  $meta->prop->{start_url} ||= "$url";
+
+  $meta->apply_plugin('Download');
+  $meta->apply_plugin('Extract', format => $self->format );
+
+  # we assume that GitLab returns the releases in reverse
+  # chronological order.
+  $meta->register_hook(
+    prefer => sub {
+      my($build, $res) = @_;
+      return $res;
+    },
+  );
+
+  croak "type must be one of source or link" if $self->type !~ /^(source|link)$/;
+  croak "version_from must be one of tag_name or name" if $self->version_from !~ /^(tag_name|name)$/;
+
+  ## TODO insert tokens as header if possible
+  ## This may help with rate limiting (or if not then don't bother)
+  # curl --header "PRIVATE-TOKEN: <your_access_token>" "https://gitlab.example.com/api/v4/projects/24/releases"
+
+  $meta->around_hook(
+    fetch => sub {
+      my $orig = shift;
+      my($build, $url, @the_rest) = @_;
+
+      # only modify the response if we are using the GitLab API
+      # to get the release list
+      return $orig->($build, $url, @the_rest)
+        if defined $url && $url ne $meta->prop->{start_url};
+
+      my $res = $orig->($build, $url, @the_rest);
+
+      my $res2 = {
+        type => 'list',
+        list => [],
+      };
+
+      $res2->{protocol} = $res->{protocol} if exists $res->{protocol};
+
+      my $rel;
+      if($res->{content})
+      {
+        $rel = decode_json $res->{content};
+      }
+      elsif($res->{path})
+      {
+        $rel = decode_json path($res->{path})->slurp_raw;
+      }
+      else
+      {
+        croak("malformed response object: no content or path");
+      }
+
+      foreach my $release (@$rel)
+      {
+        my $version = $self->version_from eq 'name' ? $release->{name} : $release->{tag_name};
+        $version = $self->convert_version->($version) if $self->convert_version;
+
+        if($self->type eq 'source')
+        {
+          foreach my $source (@{ $release->{assets}->{sources} })
+          {
+            next unless $source->{format} eq $self->format;
+            my $url = URI->new($source->{url});
+            my $filename = basename $url->path;
+            push @{ $res2->{list} }, {
+              filename => $filename,
+              url      => $source->{url},
+              version  => $version,
+            };
+          }
+        }
+        else # link
+        {
+          foreach my $link (@{ $release->{assets}->{links} })
+          {
+            my $url = URI->new($link->{url});
+            my $filename => basename $url->path;
+            if($self->link_name)
+            {
+              next unless $filename =~ $self->link_name;
+            }
+            push @{ $res2->{list} }, {
+              filename => $filename,
+              url      => $link->{url},
+              version  => $version,
+            };
+          }
+        }
+      }
+
+      return $res2;
+
+    },
+  );
 }
 
 1;
 
+=head1 SEE ALSO
 
+=over 4
+
+=item L<Alien>
+
+=item L<Alien::Build::Plugin::Download::GitHub>
+
+=item L<alienfile>
+
+=item L<Alien::Build>
+
+=back
+
+=cut

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -1,0 +1,87 @@
+use Test2::V0 -no_srand => 1;
+use Config;
+
+eval { require 'Test/More.pm' };
+
+# This .t file is generated.
+# make changes instead to dist.ini
+
+my %modules;
+my $post_diag;
+
+$modules{$_} = $_ for qw(
+  Alien::Build::Plugin
+  ExtUtils::MakeMaker
+  Test2::V0
+);
+
+
+
+my @modules = sort keys %modules;
+
+sub spacer ()
+{
+  diag '';
+  diag '';
+  diag '';
+}
+
+pass 'okay';
+
+my $max = 1;
+$max = $_ > $max ? $_ : $max for map { length $_ } @modules;
+our $format = "%-${max}s %s";
+
+spacer;
+
+my @keys = sort grep /(MOJO|PERL|\A(LC|HARNESS)_|\A(SHELL|LANG)\Z)/i, keys %ENV;
+
+if(@keys > 0)
+{
+  diag "$_=$ENV{$_}" for @keys;
+
+  if($ENV{PERL5LIB})
+  {
+    spacer;
+    diag "PERL5LIB path";
+    diag $_ for split $Config{path_sep}, $ENV{PERL5LIB};
+
+  }
+  elsif($ENV{PERLLIB})
+  {
+    spacer;
+    diag "PERLLIB path";
+    diag $_ for split $Config{path_sep}, $ENV{PERLLIB};
+  }
+
+  spacer;
+}
+
+diag sprintf $format, 'perl', "$] $^O $Config{archname}";
+
+foreach my $module (sort @modules)
+{
+  my $pm = "$module.pm";
+  $pm =~ s{::}{/}g;
+  if(eval { require $pm; 1 })
+  {
+    my $ver = eval { $module->VERSION };
+    $ver = 'undef' unless defined $ver;
+    diag sprintf $format, $module, $ver;
+  }
+  else
+  {
+    diag sprintf $format, $module, '-';
+  }
+}
+
+if($post_diag)
+{
+  spacer;
+  $post_diag->();
+}
+
+spacer;
+
+done_testing;
+

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -12,7 +12,11 @@ my $post_diag;
 $modules{$_} = $_ for qw(
   Alien::Build::Plugin
   ExtUtils::MakeMaker
+  JSON::PP
+  Path::Tiny
   Test2::V0
+  URI
+  URI::Escape
 );
 
 


### PR DESCRIPTION
We want this for 
https://gitlab.gnome.org/GNOME/libxml2

It should use the GitLab API to get the releases, which will hopefully have links to the tarballs?  Then we can download the tarball as a simple two step.  Looks like we can run GitLab in a docker container

https://docs.gitlab.com/ee/install/docker.html

which might make it possible to test locally and in CI with a real gitlab?

Not sure if we need credentials, if so that might sink this.